### PR TITLE
check where IndexedStorage::__getitem__() -> IndexedStorage is needed

### DIFF
--- a/PySDM/backends/impl_common/indexed_storage.py
+++ b/PySDM/backends/impl_common/indexed_storage.py
@@ -16,8 +16,6 @@ def make_IndexedStorage(backend):
 
         def __getitem__(self, item):
             result = backend.Storage.__getitem__(self, item)
-            if isinstance(result, backend.Storage):
-                return IndexedStorage.indexed(self.idx, result)
             return result
 
         @staticmethod


### PR DESCRIPTION
thanks @vladfedoriuk for noticing the potential problem with it (i.e., the newly created storage might not have the same length!)