### PR TITLE
Specifying git submodule path using http instead of ssh protocol. Fixes #1090

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/devops_tests"]
 	path = tests/devops_tests
-	url = git@github.com:open-atmos/devops_tests.git
+	url = https://github.com/open-atmos/devops_tests
 	shallow = true


### PR DESCRIPTION
Will fix errors on mybinder.org where attempt to clone the repo with submodules failed due to unsupported ssh communication (thanks @AgnieszkaMakulska for reporting!).