### PR TITLE
fix assert in Lowe et al 2019 smoke test 

### DIFF
--- a/tests/smoke_tests/parcel/lowe_et_al_2019/test_fig_1.py
+++ b/tests/smoke_tests/parcel/lowe_et_al_2019/test_fig_1.py
@@ -115,7 +115,7 @@ class TestFig1:
         )
 
         # act
-        peaks = signal.find_peaks(RH_eq)
+        peaks, _ = signal.find_peaks(RH_eq)
 
         # assert
         assert np.argmax(RH_eq) == (np.abs(R_WET - maximum_x)).argmin()


### PR DESCRIPTION
(what find_peaks returns is a 2-element tuple, where the first element stores peaks indices)