### PR TITLE
improving reporting of filenames in pytest example test suites

### DIFF
--- a/tests/examples_tests/conftest.py
+++ b/tests/examples_tests/conftest.py
@@ -76,7 +76,9 @@ def pytest_generate_tests(metafunc):
     if "notebook_filename" in metafunc.fixturenames:
         notebook_paths = findfiles(pysdm_examples_abs_path, r".*\.(ipynb)$")
         selected_suites = get_selected_test_suites(suite_name, notebook_paths)
-        metafunc.parametrize("notebook_filename", selected_suites)
+        metafunc.parametrize(
+            "notebook_filename", selected_suites, ids=[str(i) for i in selected_suites]
+        )
 
     if "example_filename" in metafunc.fixturenames:
         examples_paths = findfiles(
@@ -84,4 +86,6 @@ def pytest_generate_tests(metafunc):
             r".*\.(py)$",
         )
         selected_suites = get_selected_test_suites(suite_name, examples_paths)
-        metafunc.parametrize("example_filename", selected_suites)
+        metafunc.parametrize(
+            "example_filename", selected_suites, ids=[str(i) for i in selected_suites]
+        )


### PR DESCRIPTION
the idea is to improve logs which currently look like:
```
FAILED tests/examples_tests/test_run_notebooks.py::test_run_notebooks[notebook_filename3] - nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
```
so they are more informative, like:
```
FAILED tests/examples_tests/test_run_notebooks.py::test_run_notebooks[/home/slayoo/devel/PySDM/examples/PySDM_examples/Merlivat_and_Nief_1967/fig_2.ipynb] - nbclient.exceptions.CellExecutionError: An error oc...
```