### PR TITLE
pin pylint to <3.0.0 to avoid too-many-arguments issue

### DIFF
--- a/.github/workflows/tests+artifacts+pypi.yml
+++ b/.github/workflows/tests+artifacts+pypi.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # TODO #1160 https://github.com/pylint-dev/pylint/issues/9099
-        pip install pylint<3.0.0 nbqa
+        pip install "pylint<3.0.0" nbqa
         pip install pdoc3 # (pdoc3 for checking the .github/workflows/pdoc_index_workaround.py)
         pip install -r tests/devops_tests/requirements.txt
         pip install -e ./examples[tests]

--- a/.github/workflows/tests+artifacts+pypi.yml
+++ b/.github/workflows/tests+artifacts+pypi.yml
@@ -96,7 +96,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint nbqa
+        # TODO #1160 https://github.com/pylint-dev/pylint/issues/9099
+        pip install pylint<3.0.0 nbqa
         pip install pdoc3 # (pdoc3 for checking the .github/workflows/pdoc_index_workaround.py)
         pip install -r tests/devops_tests/requirements.txt
         pip install -e ./examples[tests]


### PR DESCRIPTION
see:
- https://github.com/pylint-dev/pylint/issues/8667 (cause of the problem)
- https://github.com/pylint-dev/pylint/issues/9099 (potential solution)