### PR TITLE
Revert "sort out pkg_resources deprecation using importlib.metadata (requires Python 3.8)"

### DIFF
--- a/.github/workflows/tests+artifacts+pypi.yml
+++ b/.github/workflows/tests+artifacts+pypi.yml
@@ -70,9 +70,9 @@ jobs:
         with:
           python-version: 3.9
       - run: |
-          pip install pdoc3 setuptools==58.1.0
-          pip install -e . setuptools==58.1.0
-          pip install -e examples setuptools==58.1.0
+          pip install pdoc3
+          pip install -e .
+          pip install -e examples
           python -We -m pdoc --html PySDM examples/PySDM_examples
           python -We .github/workflows/pdoc_index_workaround.py
       - if: ${{ github.ref == 'refs/heads/main' && matrix.platform == 'ubuntu-latest' }}

--- a/PySDM/__init__.py
+++ b/PySDM/__init__.py
@@ -22,7 +22,7 @@ PySDM test-suite built using [pytest](https://docs.pytest.org/) is located in th
 [tests package](https://github.com/open-atmos/PySDM/tree/master/tests).
 """
 
-from importlib.metadata import PackageNotFoundError, version
+from pkg_resources import DistributionNotFound, VersionConflict, get_distribution
 
 from . import environments, exporters, products
 from .builder import Builder
@@ -30,7 +30,7 @@ from .formulae import Formulae
 from .particulator import Particulator
 
 try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
+    __version__ = get_distribution(__name__).version
+except (DistributionNotFound, VersionConflict):
     # package is not installed
     pass

--- a/examples/PySDM_examples/__init__.py
+++ b/examples/PySDM_examples/__init__.py
@@ -2,10 +2,10 @@
 PySDM_examples package includes common Python modules used in PySDM smoke tests
 and in example notebooks (but the package wheels do not include the notebooks)
 """
-from importlib.metadata import PackageNotFoundError, version
+from pkg_resources import DistributionNotFound, VersionConflict, get_distribution
 
 try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
+    __version__ = get_distribution(__name__).version
+except (DistributionNotFound, VersionConflict):
     # package is not installed
     pass

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -24,7 +24,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "PySDM",
-        "PyMPDATA" + ">=1.0.15" if CI else "",
+        "PyMPDATA",
         "open-atmos-jupyter-utils",
         "pystrict",
         "matplotlib" + "<3.8.0" if CI else "",  # TODO #1142

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ def get_long_description():
 
 CI = "CI" in os.environ
 compat_requires = (
-    ["setuptools" + ("==58.1.0" if CI else "")]
-    if sys.version_info < (3, 10)
-    else []
+    ["setuptools" + ("==58.1.0" if CI else "")] if sys.version_info < (3, 10) else []
 )
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 the magick behind "pip install PySDM"
 """
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -13,6 +14,11 @@ def get_long_description():
 
 
 CI = "CI" in os.environ
+compat_requires = (
+    ["importlib-metadata" + ("<7.0.0" if CI else "")]
+    if sys.version_info < (3, 10)
+    else []
+)
 
 setup(
     name="PySDM",
@@ -21,7 +27,7 @@ setup(
     " examples in Python, Julia and Matlab",
     use_scm_version={"local_scheme": lambda _: "", "version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=[
+    install_requires=compat_requires + [
         "ThrustRTC==0.3.20",
         "CURandRTC" + ("==0.1.6" if CI else ">=0.1.2"),
         "numba" + ("==0.56.4" if CI else ">=0.51.2"),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_long_description():
 
 CI = "CI" in os.environ
 compat_requires = (
-    ["importlib-metadata" + ("<7.0.0" if CI else "")]
+    ["setuptools" + ("==58.1.0" if CI else "")]
     if sys.version_info < (3, 10)
     else []
 )
@@ -27,7 +27,8 @@ setup(
     " examples in Python, Julia and Matlab",
     use_scm_version={"local_scheme": lambda _: "", "version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
-    install_requires=compat_requires + [
+    install_requires=compat_requires
+    + [
         "ThrustRTC==0.3.20",
         "CURandRTC" + ("==0.1.6" if CI else ">=0.1.2"),
         "numba" + ("==0.56.4" if CI else ">=0.51.2"),


### PR DESCRIPTION
Reverts open-atmos/PySDM#1194