### PR TITLE
resolve issue with inconsistent values of rho_w and Mv constants within dry aerosol initialisation logic

### DIFF
--- a/PySDM/initialisation/aerosol_composition/dry_aerosol.py
+++ b/PySDM/initialisation/aerosol_composition/dry_aerosol.py
@@ -16,7 +16,6 @@ from typing import Dict, Tuple
 
 from PySDM import formulae
 from PySDM.physics import surface_tension
-from PySDM.physics.constants_defaults import Mv, rho_w
 
 
 class DryAerosolMixture:
@@ -94,13 +93,13 @@ class DryAerosolMixture:
         result = {}
         for st in formulae._choices(surface_tension).keys():
             if st in (surface_tension.Constant.__name__):
-                result[st] = all_soluble_ns * Mv / rho_w
+                result[st] = all_soluble_ns * const.Mv / const.rho_w
             elif st in (
                 surface_tension.CompressedFilmOvadnevaite.__name__,
                 surface_tension.CompressedFilmRuehl.__name__,
                 surface_tension.SzyszkowskiLangmuir.__name__,
             ):
-                result[st] = part_soluble_ns * Mv / rho_w
+                result[st] = part_soluble_ns * const.Mv / const.rho_w
             else:
                 raise AssertionError()
         return result

--- a/PySDM/initialisation/aerosol_composition/dry_aerosol.py
+++ b/PySDM/initialisation/aerosol_composition/dry_aerosol.py
@@ -16,6 +16,7 @@ from typing import Dict, Tuple
 
 from PySDM import formulae
 from PySDM.physics import surface_tension
+from PySDM.physics.constants_defaults import Mv, rho_w
 
 
 class DryAerosolMixture:
@@ -71,7 +72,7 @@ class DryAerosolMixture:
         return x
 
     # calculate hygroscopicities with different assumptions about solubility
-    def kappa(self, mass_fractions: dict):
+    def kappa(self, mass_fractions: dict, water_molar_mass_over_density=Mv / rho_w):
         volfrac = self.volume_fractions(mass_fractions)
         molar_volumes = {
             i: self.molar_masses[i] / self.densities[i] for i in self.compounds
@@ -93,13 +94,13 @@ class DryAerosolMixture:
         result = {}
         for st in formulae._choices(surface_tension).keys():
             if st in (surface_tension.Constant.__name__):
-                result[st] = all_soluble_ns * const.Mv / const.rho_w
+                result[st] = all_soluble_ns * water_molar_mass_over_density
             elif st in (
                 surface_tension.CompressedFilmOvadnevaite.__name__,
                 surface_tension.CompressedFilmRuehl.__name__,
                 surface_tension.SzyszkowskiLangmuir.__name__,
             ):
-                result[st] = part_soluble_ns * const.Mv / const.rho_w
+                result[st] = part_soluble_ns * water_molar_mass_over_density
             else:
                 raise AssertionError()
         return result

--- a/PySDM/initialisation/aerosol_composition/dry_aerosol.py
+++ b/PySDM/initialisation/aerosol_composition/dry_aerosol.py
@@ -72,7 +72,7 @@ class DryAerosolMixture:
         return x
 
     # calculate hygroscopicities with different assumptions about solubility
-    def kappa(self, mass_fractions: dict, water_molar_mass_over_density=Mv / rho_w):
+    def kappa(self, mass_fractions: dict, nu_w=Mv / rho_w):
         volfrac = self.volume_fractions(mass_fractions)
         molar_volumes = {
             i: self.molar_masses[i] / self.densities[i] for i in self.compounds
@@ -94,13 +94,13 @@ class DryAerosolMixture:
         result = {}
         for st in formulae._choices(surface_tension).keys():
             if st in (surface_tension.Constant.__name__):
-                result[st] = all_soluble_ns * water_molar_mass_over_density
+                result[st] = all_soluble_ns * nu_w
             elif st in (
                 surface_tension.CompressedFilmOvadnevaite.__name__,
                 surface_tension.CompressedFilmRuehl.__name__,
                 surface_tension.SzyszkowskiLangmuir.__name__,
             ):
-                result[st] = part_soluble_ns * water_molar_mass_over_density
+                result[st] = part_soluble_ns * nu_w
             else:
                 raise AssertionError()
         return result

--- a/examples/PySDM_examples/Abdul_Razzak_Ghan_2000/aerosol.py
+++ b/examples/PySDM_examples/Abdul_Razzak_Ghan_2000/aerosol.py
@@ -11,7 +11,7 @@ CONSTANTS_ARG = {
     "Mv": 18.015 * si.g / si.mol,
     "Md": 28.97 * si.g / si.mol,
 }
-water_molar_mass_over_density = CONSTANTS_ARG["Mv"] / rho_w
+nu_w = CONSTANTS_ARG["Mv"] / rho_w
 
 
 @strict
@@ -39,13 +39,13 @@ class AerosolARG(DryAerosolMixture):
         )
         self.modes = (
             {
-                "kappa": self.kappa(mode1, water_molar_mass_over_density),
+                "kappa": self.kappa(mode1, nu_w),
                 "spectrum": spectra.Lognormal(
                     norm_factor=100.0 / si.cm**3, m_mode=50.0 * si.nm, s_geom=2.0
                 ),
             },
             {
-                "kappa": self.kappa(mode2, water_molar_mass_over_density),
+                "kappa": self.kappa(mode2, nu_w),
                 "spectrum": spectra.Lognormal(
                     norm_factor=M2_N, m_mode=M2_rad, s_geom=2.0
                 ),
@@ -73,19 +73,19 @@ class AerosolWhitby(DryAerosolMixture):
         )
         self.modes = (
             {
-                "kappa": self.kappa(nuclei, water_molar_mass_over_density),
+                "kappa": self.kappa(nuclei, nu_w),
                 "spectrum": spectra.Lognormal(
                     norm_factor=1000.0 / si.cm**3, m_mode=0.008 * si.um, s_geom=1.6
                 ),
             },
             {
-                "kappa": self.kappa(accum, water_molar_mass_over_density),
+                "kappa": self.kappa(accum, nu_w),
                 "spectrum": spectra.Lognormal(
                     norm_factor=800 / si.cm**3, m_mode=0.034 * si.um, s_geom=2.1
                 ),
             },
             {
-                "kappa": self.kappa(coarse, water_molar_mass_over_density),
+                "kappa": self.kappa(coarse, nu_w),
                 "spectrum": spectra.Lognormal(
                     norm_factor=0.72 / si.cm**3, m_mode=0.46 * si.um, s_geom=2.2
                 ),

--- a/examples/PySDM_examples/Abdul_Razzak_Ghan_2000/aerosol.py
+++ b/examples/PySDM_examples/Abdul_Razzak_Ghan_2000/aerosol.py
@@ -4,12 +4,14 @@ from pystrict import strict
 from PySDM.initialisation import spectra
 from PySDM.initialisation.aerosol_composition import DryAerosolMixture
 from PySDM.physics import si
+from PySDM.physics.constants_defaults import rho_w
 
 # not in the paper - guessed and checked to match
 CONSTANTS_ARG = {
     "Mv": 18.015 * si.g / si.mol,
     "Md": 28.97 * si.g / si.mol,
 }
+water_molar_mass_over_density = CONSTANTS_ARG["Mv"] / rho_w
 
 
 @strict
@@ -20,6 +22,8 @@ class AerosolARG(DryAerosolMixture):
         M2_N: float = 100 / si.cm**3,
         M2_rad: float = 50 * si.nm,
     ):
+        mode1 = {"(NH4)2SO4": 1.0, "insoluble": 0.0}
+        mode2 = {"(NH4)2SO4": M2_sol, "insoluble": (1 - M2_sol)}
         super().__init__(
             compounds=("(NH4)2SO4", "insoluble"),
             molar_masses={
@@ -35,13 +39,13 @@ class AerosolARG(DryAerosolMixture):
         )
         self.modes = (
             {
-                "kappa": self.kappa({"(NH4)2SO4": 1.0, "insoluble": 0.0}),
+                "kappa": self.kappa(mode1, water_molar_mass_over_density),
                 "spectrum": spectra.Lognormal(
                     norm_factor=100.0 / si.cm**3, m_mode=50.0 * si.nm, s_geom=2.0
                 ),
             },
             {
-                "kappa": self.kappa({"(NH4)2SO4": M2_sol, "insoluble": (1 - M2_sol)}),
+                "kappa": self.kappa(mode2, water_molar_mass_over_density),
                 "spectrum": spectra.Lognormal(
                     norm_factor=M2_N, m_mode=M2_rad, s_geom=2.0
                 ),
@@ -69,19 +73,19 @@ class AerosolWhitby(DryAerosolMixture):
         )
         self.modes = (
             {
-                "kappa": self.kappa(nuclei),
+                "kappa": self.kappa(nuclei, water_molar_mass_over_density),
                 "spectrum": spectra.Lognormal(
                     norm_factor=1000.0 / si.cm**3, m_mode=0.008 * si.um, s_geom=1.6
                 ),
             },
             {
-                "kappa": self.kappa(accum),
+                "kappa": self.kappa(accum, water_molar_mass_over_density),
                 "spectrum": spectra.Lognormal(
                     norm_factor=800 / si.cm**3, m_mode=0.034 * si.um, s_geom=2.1
                 ),
             },
             {
-                "kappa": self.kappa(coarse),
+                "kappa": self.kappa(coarse, water_molar_mass_over_density),
                 "spectrum": spectra.Lognormal(
                     norm_factor=0.72 / si.cm**3, m_mode=0.46 * si.um, s_geom=2.2
                 ),


### PR DESCRIPTION
@claresinger this is just a first commit to start working on fixing the issue of using within the dry-aerosol initialization values of `Mv` and `rho_w` that are inconsistent with what is within `formulae.constants` (that includes values optionally overridden from Formulae ctor).

Would it make sense for the `kappa()` function to accept an instance of `Formulae` and return a value for the very surface tension selected in this instance, instead of returning a dictionary?