### PR TITLE
refactor freezing code moving Poissonian void probability formula to Trivia; support for docstrings in Formulae._c_inline()

### DIFF
--- a/PySDM/backends/impl_numba/methods/freezing_methods.py
+++ b/PySDM/backends/impl_numba/methods/freezing_methods.py
@@ -54,6 +54,7 @@ class FreezingMethods(BackendMethods):
         self.freeze_singular_body = freeze_singular_body
 
         j_het = self.formulae.heterogeneous_ice_nucleation_rate.j_het
+        prob_zero_events = self.formulae.trivia.poissonian_avoidance_function
 
         @numba.njit(**self.default_jit_flags)
         def freeze_time_dependent_body(  # pylint: disable=unused-argument,too-many-arguments
@@ -80,10 +81,11 @@ class FreezingMethods(BackendMethods):
                 elif unfrozen_and_saturated(
                     attributes.water_mass[i], relative_humidity[cell_id]
                 ):
-                    rate = j_het(a_w_ice[cell_id])
-                    # TODO #594: this assumes constant T throughout timestep, can we do better?
-                    prob = 1 - np.exp(  # TODO #599: common code for Poissonian prob
-                        -rate * attributes.immersed_surface_area[i] * timestep
+                    rate_assuming_constant_temperature_within_dt = (
+                        j_het(a_w_ice[cell_id]) * attributes.immersed_surface_area[i]
+                    )
+                    prob = 1 - prob_zero_events(
+                        r=rate_assuming_constant_temperature_within_dt, dt=timestep
                     )
                     if rand[i] < prob:
                         _freeze(attributes.water_mass, i)

--- a/PySDM/backends/impl_numba/methods/freezing_methods.py
+++ b/PySDM/backends/impl_numba/methods/freezing_methods.py
@@ -3,7 +3,6 @@ CPU implementation of backend methods for freezing (singular and time-dependent 
 """
 
 import numba
-import numpy as np
 
 from PySDM.backends.impl_common.backend_methods import BackendMethods
 

--- a/PySDM/backends/impl_thrust_rtc/methods/freezing_methods.py
+++ b/PySDM/backends/impl_thrust_rtc/methods/freezing_methods.py
@@ -40,12 +40,13 @@ class FreezingMethods(ThrustRTCBackendMethods):
                         water_mass="water_mass[i]",
                         relative_humidity="relative_humidity[cell[i]]"
                     )}) {{
-                    auto rate = {self.formulae.heterogeneous_ice_nucleation_rate.j_het.c_inline(
+                    auto rate_assuming_constant_temperature_within_dt = {self.formulae.heterogeneous_ice_nucleation_rate.j_het.c_inline(
                         a_w_ice="a_w_ice[cell[i]]"
+                    )} * immersed_surface_area[i];
+                    auto prob = 1 - {self.formulae.trivia.poissonian_avoidance_function.c_inline(
+                        r="rate_assuming_constant_temperature_within_dt",
+                        dt="timestep"
                     )};
-                    auto prob = 1 - exp(
-                        -rate * immersed_surface_area[i] * timestep
-                    );
                     if (rand[i] < prob) {{
                         water_mass[i] = -1 * water_mass[i];
                     }}

--- a/PySDM/formulae.py
+++ b/PySDM/formulae.py
@@ -269,11 +269,19 @@ def _c_inline(fun, return_type=None, constants=None, **args):
     post = r"([ )/*\-+,]|$)"
     real_fmt = ".32g"
     source = ""
+    in_docstring = False
     for line in inspect.getsourcelines(fun)[0]:
         stripped = line.strip()
+        if in_docstring:
+            if stripped.endswith('"""'):
+                in_docstring = False
+            continue
         if stripped.startswith("@"):
             continue
         if stripped.startswith("//"):
+            continue
+        if stripped.startswith('"""'):
+            in_docstring = True
             continue
         if stripped.startswith("def "):
             continue

--- a/PySDM/physics/trivia.py
+++ b/PySDM/physics/trivia.py
@@ -137,3 +137,11 @@ class Trivia:  # pylint: disable=too-many-public-methods
     @staticmethod
     def sqrt_re_times_cbrt_sc(const, Re, Sc):
         return np.power(Re, const.ONE_HALF) * np.power(Sc, const.ONE_THIRD)
+
+    @staticmethod
+    def poissonian_avoidance_function(r, dt):
+        """cumulative probability of zero events occurring within time `dt`
+        (or void probability, or avoidance function) in a Poisson counting
+        process with a constant rate `r`
+        """
+        return np.exp(-r * dt)

--- a/tests/unit_tests/physics/test_trivia.py
+++ b/tests/unit_tests/physics/test_trivia.py
@@ -72,3 +72,20 @@ class TestTrivia:
 
             # Assert
             assert sc.check("[]")
+
+    @staticmethod
+    def test_poissonian_avoidance_function():
+        with DimensionalAnalysis():
+            # Arrange
+            formulae = Formulae()
+            si = constants_defaults.si
+            sut = formulae.trivia.poissonian_avoidance_function
+
+            # Act
+            sc = sut(
+                r=1 / si.s,
+                dt=10 * si.min,
+            )
+
+            # Assert
+            assert sc.check("[]")


### PR DESCRIPTION
@claresinger, @AgnieszkaZaba, this PR is extracts common code for computing (zero event) probability from a Poisson process rate - anticipating that the formula will also be used in homogeneous freezing Monte-Carlo logic