### PR TITLE
switch from mp4 to gif for Paraview-generated animations (ffmpeg conv erted)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,7 +286,7 @@ jobs:
           rm /tmp/pytest/test_run_notebooks_*current
           ls /tmp/pytest/test_run_notebooks_*/
           ls /tmp/pytest/test_run_notebooks_*/output/
-          ffmpeg -i /tmp/pytest/test_run_notebooks_*/output/docs_intro_animation.ogv $HOME/work/_temp/_github_home/figures/docs_intro_animation_${{ matrix.platform }}.mp4
+          ffmpeg -i /tmp/pytest/test_run_notebooks_*/output/docs_intro_animation.ogv -loop 0 -vf "fps=10,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" $HOME/work/_temp/_github_home/figures/docs_intro_animation_${{ matrix.platform }}.gif
           mv /tmp/pytest/test_run_notebooks_*/output/last_animation_frame.pdf $HOME/work/_temp/_github_home/figures/last_animation_frame_${{ matrix.platform }}.pdf
           ls $HOME/work/_temp/_github_home/figures
 
@@ -296,7 +296,7 @@ jobs:
         with:
           name: animation-movie-${{ matrix.platform }}
           if-no-files-found: error
-          path: ~/work/_temp/_github_home/figures/*.mp4
+          path: ~/work/_temp/_github_home/figures/*.gif
 
       - name: animation frame upload
         if: ( ! startsWith(matrix.platform, 'windows-') ) && matrix.test-suite == env.anim_test-suite && matrix.python-version == env.anim_python-version
@@ -311,4 +311,4 @@ jobs:
         uses: eine/tip@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: /github/home/figures/*.mp4
+          files: /github/home/figures/*.gif

--- a/docs/templates/index.html.jinja2
+++ b/docs/templates/index.html.jinja2
@@ -32,11 +32,8 @@
         <h2>What is PySDM?</h2>
         <p>
             <div style="float:right; width:40%">
-            <video controls style="width:100%">
-                <source src="https://github.com/open-atmos/PySDM/releases/download/tip/docs_intro_animation_ubuntu-24.04.mp4" type="video/mp4">
-                Your browser does not support the video tag.
-            </video>
-            <a href="https://github.com/open-atmos/PySDM/blob/main/examples/PySDM_examples/_HOWTOs/paraview_hello_world.ipynb" style="small">Jupyter notebook setting up and running the above PySDM simulation and generating the visualisation using Paraview</a>
+              <img style="width:100%" src="https://github.com/open-atmos/PySDM/releases/download/tip/docs_intro_animation_ubuntu-24.04.gif" />
+              <a href="https://github.com/open-atmos/PySDM/blob/main/examples/PySDM_examples/_HOWTOs/paraview_hello_world.ipynb" style="small">Jupyter notebook setting up and running the above PySDM simulation and generating the visualisation using Paraview</a>
             </div>
             PySDM is a package for simulating the <mark>dynamics of population of particles undergoing diffusional and collisional growth (and breakage)</mark>.
             The package features a Pythonic high-performance (multi-threaded CPU &amp; CUDA GPU) implementation of the <mark>Super-Droplet Method (SDM) Monte-Carlo algorithm</mark> 

--- a/examples/docs/pysdm_examples_landing.md
+++ b/examples/docs/pysdm_examples_landing.md
@@ -43,10 +43,7 @@ The 2D prescribed-flow framework used here can be traced back to the work of
   (<a href="https://github.com/open-atmos/PySDM/blob/main/examples/PySDM_examples/_HOWTOs/paraview_hello_world.ipynb">see
   the Paraview hello-world HOWTO Jupyter notbook for code generating the simulation and visualisation</a>):
 <center>
-<video controls style="width:80%">
-  <source src="https://github.com/open-atmos/PySDM/releases/download/tip/docs_intro_animation_ubuntu-24.04.mp4" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+  <img src="https://github.com/open-atmos/PySDM/releases/download/tip/docs_intro_animation_ubuntu-24.04.gif" style="width:80%" />
 </center>
 
 Example notebooks:


### PR DESCRIPTION
GitHub serves the mp4s with Content-disposition attachment making it not work with the <video> HTML tag