### PR TITLE
adding CI version pins to readme_snippet workflow

### DIFF
--- a/.github/workflows/readme_snippets.yml
+++ b/.github/workflows/readme_snippets.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
-      - run: python -m pip install $PIP_INSTALL_ARGS -e .
+      - run: python -m pip install $PIP_INSTALL_ARGS -e .[CI_version_pins]
       - run: python -m pip install $PIP_INSTALL_ARGS pytest-codeblocks pytest
       - run: |
           python -c "import os,pytest_codeblocks; code=pytest_codeblocks.extract_from_file('docs/markdown/pysdm_landing.md'); f=open('readme.py', 'w', encoding='utf-8'); f.write('# coding: utf-8'+os.linesep); f.writelines(block.code for block in code if block.syntax=='Python'); f.close()"


### PR DESCRIPTION
@slayoo @Sfonxu
With [0.63. Numba release](https://numba.readthedocs.io/en/stable/release/0.63.0-notes.html) support for macOS (intel) is depreciated.

In readme_snippet workflow we install latest Numba causing error.
I added CI_version_pins to this run, but maybe there is a better way?

- specifying numba==0.62 for macOS on Intel
- leaving only runs on macOS ARM
- 
What do you think?