### PR TITLE
Update README to reflect changes in dependency file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For development purposes, we suggest cloning the repository and installing it us
 Test-time dependencies can be installed with ``pip -e .[tests]``.
 
 PySDM examples constitute the [``PySDM-examples``](https://github.com/open-atmos/PySDM/blob/main/examples) package.
-The examples have additional dependencies listed in [``PySDM_examples`` package ``setup.py``](https://github.com/open-atmos/PySDM/blob/main/examples/setup.py) file.
+The examples have additional dependencies listed in [``PySDM_examples`` package ``pyproject.toml``](https://github.com/open-atmos/PySDM/blob/main/examples/pyproject.toml) file.
 Running the example Jupyter notebooks requires the ``PySDM_examples`` package to be installed.
 The suggested install and launch steps are:
 ```


### PR DESCRIPTION
Updated the documentation to reference 'pyproject.toml' instead of 'setup.py' for additional dependencies.