### PR TITLE
SDM core algorithm bugfix: pair-number normalization for multi-cell setups

### DIFF
--- a/PySDM/backends/impl_numba/methods/collisions_methods.py
+++ b/PySDM/backends/impl_numba/methods/collisions_methods.py
@@ -631,7 +631,7 @@ class CollisionsMethods(BackendMethods):
     @cached_property
     def _normalize_body(self):
         @numba.njit(**{**self.default_jit_flags, **{"parallel": False}})
-        def body(prob, cell_id, cell_idx, cell_start, norm_factor, timestep, dv):
+        def body(prob, cell_start, norm_factor, timestep, dv):
             n_cell = cell_start.shape[0] - 1
             for i in range(n_cell):
                 sd_num = cell_start[i + 1] - cell_start[i]
@@ -641,18 +641,17 @@ class CollisionsMethods(BackendMethods):
                     norm_factor[i] = (
                         timestep / dv * sd_num * (sd_num - 1) / 2 / (sd_num // 2)
                     )
-            for d in numba.prange(prob.shape[0]):  # pylint: disable=not-an-iterable
-                prob[d] *= norm_factor[cell_idx[cell_id[d]]]
+            for i in numba.prange(n_cell):  # pylint: disable=not-an-iterable
+                for pair_start in range(cell_start[i], cell_start[i + 1] - 1, 2):
+                    prob[pair_start // 2] *= norm_factor[i]
 
         return body
 
     def normalize(
         self, prob, cell_id, cell_idx, cell_start, norm_factor, timestep, dv
-    ):  # pylint: disable=too-many-positional-arguments
+    ):  # pylint: disable=too-many-positional-arguments,unused-argument
         return self._normalize_body(
             prob.data,
-            cell_id.data,
-            cell_idx.data,
             cell_start.data,
             norm_factor.data,
             timestep,

--- a/PySDM/backends/impl_thrust_rtc/methods/collisions_methods.py
+++ b/PySDM/backends/impl_thrust_rtc/methods/collisions_methods.py
@@ -483,10 +483,12 @@ class CollisionsMethods(
     @cached_property
     def __normalize_body_1(self):
         return trtc.For(
-            param_names=("prob", "cell_id", "norm_factor"),
+            param_names=("prob", "cell_start", "norm_factor"),
             name_iter="i",
             body="""
-            prob[i] *= norm_factor[cell_id[i]];
+            for (auto pair_start = cell_start[i]; pair_start < cell_start[i + 1] - 1; pair_start += 2) {
+                prob[(int64_t)(pair_start / 2)] *= norm_factor[i];
+            }
             """,
         )
 
@@ -918,7 +920,7 @@ class CollisionsMethods(
             n=n_cell, args=(cell_start.data, norm_factor.data, device_dt_div_dv)
         )
         self.__normalize_body_1.launch_n(
-            prob.shape[0], (prob.data, cell_id.data, norm_factor.data)
+            n_cell, (prob.data, cell_start.data, norm_factor.data)
         )
 
     @nice_thrust(**NICE_THRUST_FLAGS)

--- a/tests/unit_tests/backends/test_collisions_methods.py
+++ b/tests/unit_tests/backends/test_collisions_methods.py
@@ -374,3 +374,47 @@ class TestCollisionMethods:
         np.testing.assert_allclose(
             actual=prob.to_ndarray(), desired=[1 * mult] * (n_sd // 2)
         )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "cell_start, expected",
+        (
+            ([0, 4, 8], [3, 3, 3, 3]),
+            ([0, 5, 7], [5, 5, 1]),
+            ([0, 3, 9], [3, 5, 5, 5]),
+            ([0, 1, 5], [3, 3]),
+        ),
+    )
+    def test_normalize_multiple_cells(backend_instance, cell_start, expected):
+        backend = backend_instance
+
+        # Arrange
+        n_sd = cell_start[-1]
+        n_cell = len(cell_start) - 1
+        cell_start = backend.Storage.from_ndarray(np.asarray(cell_start))
+        cell_id = backend.Storage.from_ndarray(
+            np.repeat(np.arange(n_cell), np.diff(cell_start.to_ndarray()))
+        )
+        cell_idx = backend.Storage.from_ndarray(np.arange(n_cell))
+        norm_factor = backend.Storage.from_ndarray(np.full(n_cell, np.nan))
+        prob = backend.Storage.from_ndarray(np.ones(n_sd // 2))
+
+        timestep = 44
+        dv = 666
+
+        # Act
+        backend.normalize(
+            prob=prob,
+            cell_id=cell_id,
+            cell_idx=cell_idx,
+            cell_start=cell_start,
+            norm_factor=norm_factor,
+            timestep=timestep,
+            dv=dv,
+        )
+
+        # Assert
+        np.testing.assert_allclose(
+            actual=prob.to_ndarray(),
+            desired=np.asarray(expected) * timestep / dv,
+        )


### PR DESCRIPTION
`normalize` now uses normalize coefficient correctly

fixes open-atmos/PySDM/issues/1925